### PR TITLE
Update RangeSliderControl.cs

### DIFF
--- a/Xamarin.RangeSlider.Droid/RangeSliderControl.cs
+++ b/Xamarin.RangeSlider.Droid/RangeSliderControl.cs
@@ -937,8 +937,8 @@ namespace Xamarin.RangeSlider
         {
             var bundle = new Bundle();
             bundle.PutParcelable("SUPER", base.OnSaveInstanceState());
-            bundle.PutDouble("MIN", NormalizedMinValue);
-            bundle.PutDouble("MAX", NormalizedMaxValue);
+            bundle.PutFloat("MIN", NormalizedMinValue);
+            bundle.PutFloat("MAX", NormalizedMaxValue);
             return bundle;
         }
 


### PR DESCRIPTION
Corrected value types for the normalised min and max values. Currently when restoring state the values fail to be read with `java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Float` and are reset to 0.

NB the only edits I made are to OnSaveInstanceState, git has automangled the line endings...