### PR TITLE
Control can be null in Xamarin.Forms 4.

### DIFF
--- a/Xamarin.RangeSlider.Forms.iOS/RangeSliderRenderer.cs
+++ b/Xamarin.RangeSlider.Forms.iOS/RangeSliderRenderer.cs
@@ -128,7 +128,7 @@ namespace Xamarin.RangeSlider.Forms
             {
                 Control.FormatLabel = Element.FormatLabel;
             }
-            Control.SetNeedsLayout();
+            Control?.SetNeedsLayout();
         }
 
         private void ForceFormsLayout()


### PR DESCRIPTION
For reproduce:
1. Create a new project (Mobile App (Xamarin.Forms) with Master-Detail template).
2. Add Xamarin.Forms.RangeSlider NuGet package.
3. Add page with RangeSlider.
4. Navigate to page with RangeSlider.
5. Navigate to another page.
6. Take NullReferenceException.