### PR TITLE
Fix iOS RangedSlider in iOS page/formsheets, and added active color support for iOS

### DIFF
--- a/Xamarin.RangeSlider.Forms.Droid/RangeSliderRenderer.cs
+++ b/Xamarin.RangeSlider.Forms.Droid/RangeSliderRenderer.cs
@@ -136,7 +136,7 @@ namespace Xamarin.RangeSlider.Forms
                 if (Element.ActiveColor != Xamarin.Forms.Color.Default)
                     Control.ActiveColor = Element.ActiveColor.ToAndroid();
             }
-            else if (e.PropertyName == RangeSlider.MaterialUiProperty.PropertyName)
+            else if (e.PropertyName == RangeSlider.MaterialUIProperty.PropertyName)
             {
                 Control.MaterialUI = Element.MaterialUI;
             }

--- a/Xamarin.RangeSlider.Forms.Samples/Xamarin.RangeSlider.Forms.Samples/MainPage.xaml
+++ b/Xamarin.RangeSlider.Forms.Samples/Xamarin.RangeSlider.Forms.Samples/MainPage.xaml
@@ -6,10 +6,11 @@
 			<samples:StringToIntConverter x:Key="StringToIntConverter" />
 		</ResourceDictionary>
 	</ContentPage.Resources>
+
 	<ContentPage.Padding>
 		<OnPlatform x:TypeArguments="Thickness">
 			<OnPlatform.iOS>
-				0, 20, 0, 0
+				0, 40, 0, 0
 			</OnPlatform.iOS>
 			<OnPlatform.Android>
 				0, 0, 0, 0
@@ -19,11 +20,16 @@
 			</OnPlatform.WinPhone>
 		</OnPlatform>
 	</ContentPage.Padding>
+
 	<ScrollView>
 		<Grid x:Name="Grid">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto"  />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
@@ -69,10 +75,24 @@
                          UpperValue="{Binding UpperValue, Mode=TwoWay}" StepValue="{Binding StepValue}" StepValueContinuously="{Binding StepValueContinuously}" VerticalOptions="{Binding VerticalOptions}" TextSize="{Binding TextSize}" TextColor="{Binding TextColor}" 
                          MinThumbHidden="{Binding MinThumbHidden}" MaxThumbHidden="{Binding MaxThumbHidden}" BarHeight="{Binding BarHeight}" ShowTextAboveThumbs="{Binding ShowTextAboveThumbs}" IsEnabled="{Binding IsEnabled}"/>
 			<Label Grid.Column="2" Grid.Row="10" BindingContext="{x:Reference Name=RangeSliderWithEffect}" Text="{Binding UpperValue, StringFormat='{0:F2}'}" VerticalOptions="Center"/>
-      <Switch Grid.Row="11" BindingContext="{x:Reference Name=RangeSlider}" IsToggled="{Binding MinThumbTextHidden, Mode=TwoWay}" VerticalOptions="Center" />
-      <Label Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Text="Min Thumb Text Hidden" VerticalOptions="Center" />
-      <Switch Grid.Row="12" BindingContext="{x:Reference Name=RangeSlider}" IsToggled="{Binding MaxThumbTextHidden, Mode=TwoWay}" VerticalOptions="Center" />
-      <Label Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" Text="Max Thumb Text Hidden" VerticalOptions="Center" />
-    </Grid>
+			<Switch Grid.Row="11" BindingContext="{x:Reference Name=RangeSlider}" IsToggled="{Binding MinThumbTextHidden, Mode=TwoWay}" VerticalOptions="Center" />
+			<Label Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Text="Min Thumb Text Hidden" VerticalOptions="Center" />
+			<Switch Grid.Row="12" BindingContext="{x:Reference Name=RangeSlider}" IsToggled="{Binding MaxThumbTextHidden, Mode=TwoWay}" VerticalOptions="Center" />
+			<Label Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="2" Text="Max Thumb Text Hidden" VerticalOptions="Center" />
+
+			<Label Grid.Row="13" Grid.ColumnSpan="2" Text="Active Color" />
+			<StackLayout Grid.Row="14" Grid.ColumnSpan="3" Orientation="Horizontal" VerticalOptions="Start">
+				<Entry x:Name="ActiveColorEntry" Text="Default" VerticalOptions="Center" HorizontalOptions="FillAndExpand" />
+				<BoxView x:Name="ActiveColorBox" VerticalOptions="Center" />
+				<Button Text="Set" Clicked="SetActiveColor_Clicked" VerticalOptions="Center" />
+			</StackLayout>
+
+			<Label Grid.Row="15" Grid.ColumnSpan="2" Text="Text Color" />
+			<StackLayout Grid.Row="16" Grid.ColumnSpan="3" Orientation="Horizontal" VerticalOptions="Start">
+				<Entry x:Name="TextColorEntry" Text="Default" VerticalOptions="Center" HorizontalOptions="FillAndExpand" />
+				<BoxView x:Name="TextColorBox" VerticalOptions="Center" />
+				<Button Text="Set" Clicked="SetTextColor_Clicked" VerticalOptions="Center" />
+			</StackLayout>
+		</Grid>
 	</ScrollView>
 </ContentPage>

--- a/Xamarin.RangeSlider.Forms.Samples/Xamarin.RangeSlider.Forms.Samples/MainPage.xaml.cs
+++ b/Xamarin.RangeSlider.Forms.Samples/Xamarin.RangeSlider.Forms.Samples/MainPage.xaml.cs
@@ -42,5 +42,34 @@ namespace Xamarin.RangeSlider.Forms.Samples
         {
             Debug.WriteLine("RangeSliderOnDragStarted");
         }
+
+        private void SetActiveColor_Clicked(object sender, EventArgs e)
+        {
+            var color = Color.FromHex(ActiveColorEntry.Text);
+
+            RangeSlider.ActiveColor = color;
+            RangeSliderWithEffect.ActiveColor = color;
+            ActiveColorBox.BackgroundColor = color;
+
+            ActiveColorEntry.Text = ColorToString(color);
+        }
+
+        private void SetTextColor_Clicked(object sender, EventArgs e)
+        {
+            var color = Color.FromHex(TextColorEntry.Text);
+
+            RangeSlider.TextColor = color;
+            RangeSliderWithEffect.TextColor = color;
+            TextColorBox.BackgroundColor = color;
+
+            TextColorEntry.Text = ColorToString(color);
+        }
+
+        private static string ColorToString(Color color)
+        {
+            return color == Color.Default ?
+                "Default" :
+                string.Format("#{0:X}{1:X}{2:X}{3:X}", (int)(color.A * 255), (int)(color.R * 255), (int)(color.G * 255), (int)(color.B * 255));
+        }
     }
 }

--- a/Xamarin.RangeSlider.Forms.iOS/RangeSliderRenderer.cs
+++ b/Xamarin.RangeSlider.Forms.iOS/RangeSliderRenderer.cs
@@ -59,6 +59,8 @@ namespace Xamarin.RangeSlider.Forms
             control.TextFormat = element.TextFormat;
             if (element.TextColor != Color.Default)
                 control.TextColor = element.TextColor.ToUIColor();
+            if (element.ActiveColor != Color.Default)
+                control.ActiveColor = element.ActiveColor.ToUIColor();
             control.FormatLabel = element.FormatLabel;
         }
 
@@ -123,6 +125,11 @@ namespace Xamarin.RangeSlider.Forms
             {
                 if (Element.TextColor != Color.Default)
                     Control.TextColor = Element.TextColor.ToUIColor();
+            }
+            else if (e.PropertyName == RangeSlider.ActiveColorProperty.PropertyName)
+            {
+                if (Element.ActiveColor != Color.Default)
+                    Control.ActiveColor = Element.ActiveColor.ToUIColor();
             }
             else if (e.PropertyName == RangeSlider.FormatLabelProperty.PropertyName)
             {

--- a/Xamarin.RangeSlider.Forms/RangeSlider.cs
+++ b/Xamarin.RangeSlider.Forms/RangeSlider.cs
@@ -59,7 +59,7 @@ namespace Xamarin.RangeSlider.Forms
         public static readonly BindableProperty ActiveColorProperty =
             BindableProperty.Create(nameof(ActiveColor), typeof(Color), typeof(RangeSlider), Color.Default);
 
-        public static readonly BindableProperty MaterialUiProperty =
+        public static readonly BindableProperty MaterialUIProperty =
             BindableProperty.Create(nameof(MaterialUI), typeof(bool), typeof(RangeSlider), false);
 
         public float MinimumValue
@@ -161,8 +161,8 @@ namespace Xamarin.RangeSlider.Forms
 
         public bool MaterialUI
         {
-            get => (bool)GetValue(MaterialUiProperty);
-            set => SetValue(MaterialUiProperty, value);
+            get => (bool)GetValue(MaterialUIProperty);
+            set => SetValue(MaterialUIProperty, value);
         }
 
         public Func<Thumb, float, string> FormatLabel

--- a/Xamarin.RangeSlider.iOS/RangeSliderControl.cs
+++ b/Xamarin.RangeSlider.iOS/RangeSliderControl.cs
@@ -71,6 +71,7 @@ namespace Xamarin.RangeSlider
         private float _textSize = 10;
         private string _textFormat = "F0";
         private UIColor _textColor;
+        private UIColor _activeColor;
         private float _lowerValue;
         private float _maximumValue;
         private float _minimumRange;
@@ -299,6 +300,18 @@ namespace Xamarin.RangeSlider
             }
         }
 
+        [Export(nameof(ActiveColor))]
+        [Browsable(true)]
+        public UIColor ActiveColor
+        {
+            get { return _activeColor; }
+            set
+            {
+                _activeColor = value;
+                SetNeedsLayout();
+            }
+        }
+
         [Export(nameof(LowerHandleLabelHidden))]
         [Browsable(true)]
         public bool LowerHandleLabelHidden
@@ -382,6 +395,7 @@ namespace Xamarin.RangeSlider
 
                 var image = ImageFromBundle(@"slider-default7-trackCrossedOver");
                 image = image.CreateResizableImage(new UIEdgeInsets(0.0f, 2.0f, 0.0f, 2.0f));
+                image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
                 _trackCrossedOverImage = image;
 
                 return _trackCrossedOverImage;
@@ -396,7 +410,9 @@ namespace Xamarin.RangeSlider
                     return _lowerHandleImageNormal;
 
                 var image = ImageFromBundle(Enabled ? @"slider-default7-handle" : @"slider-default7-handle-disabled");
-                _lowerHandleImageNormal = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+                _lowerHandleImageNormal = image;
 
                 return _lowerHandleImageNormal;
             }
@@ -410,7 +426,9 @@ namespace Xamarin.RangeSlider
                     return _lowerHandleImageHighlighted;
 
                 var image = ImageFromBundle(@"slider-default7-handle");
-                _lowerHandleImageHighlighted = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+                _lowerHandleImageHighlighted = image;
 
                 return _lowerHandleImageHighlighted;
             }
@@ -424,7 +442,9 @@ namespace Xamarin.RangeSlider
                     return _upperHandleImageNormal;
 
                 var image = ImageFromBundle(Enabled ? @"slider-default7-handle" : @"slider-default7-handle-disabled");
-                _upperHandleImageNormal = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+                _upperHandleImageNormal = image;
 
                 return _upperHandleImageNormal;
             }
@@ -437,7 +457,9 @@ namespace Xamarin.RangeSlider
                 if (_upperHandleImageHighlighted != null)
                     return _upperHandleImageHighlighted;
                 var image = ImageFromBundle(@"slider-default7-handle");
-                _upperHandleImageHighlighted = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithAlignmentRectInsets(new UIEdgeInsets(-1, 8, 1, 8));
+                image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+                _upperHandleImageHighlighted = image;
 
                 return _upperHandleImageHighlighted;
             }
@@ -840,17 +862,20 @@ namespace Xamarin.RangeSlider
             _trackBackground.Frame = TrackBackgroundRect();
             _track.Frame = TrackRect();
             _track.Image = TrackImageForCurrentValues;
+            _track.TintColor = ActiveColor;
 
             // Layout the lower handle
             _lowerHandle.Frame = ThumbRectForValue(LowerValue, LowerHandleImageNormal);
             _lowerHandle.Image = LowerHandleImageNormal;
             _lowerHandle.HighlightedImage = LowerHandleImageHighlighted;
+            _lowerHandle.TintColor = ActiveColor;
             _lowerHandle.Hidden = _lowerHandleHidden;
 
             // Layoput the upper handle
             _upperHandle.Frame = ThumbRectForValue(UpperValue, UpperHandleImageNormal);
             _upperHandle.Image = UpperHandleImageNormal;
             _upperHandle.HighlightedImage = UpperHandleImageHighlighted;
+            _upperHandle.TintColor = ActiveColor;
             _upperHandle.Hidden = _upperHandleHidden;
 
             _lowerHandleLabel.Text = ValueToString(LowerValue, Thumb.Lower);


### PR DESCRIPTION
This fixes https://github.com/halkar/xamarin-range-slider/issues/167, by stopping event propagation when slider is dragged.

This also implements https://github.com/halkar/xamarin-range-slider/issues/150, by adding ActiveColor support for iOS.
<img width="584" alt="Screenshot 2020-08-23 at 1 34 23" src="https://user-images.githubusercontent.com/60286968/90966996-b7c2e880-e4e1-11ea-97b4-4f75e9c876fa.png">